### PR TITLE
Prevent zero x coordinate being used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/corvus-ch/shamir
+
+go 1.18

--- a/shamir.go
+++ b/shamir.go
@@ -195,9 +195,16 @@ func NewWriter(parts, threshold int, factory func(x byte) (io.Writer, error)) (i
 		if _, err := rand.Read(buf); err != nil {
 			return nil, err
 		}
+		x := buf[0]
+
+		if x == 0 {
+			// We cannot use a zero x coordinate otherwise the y values would be the intercepts i.e. the secret value itself.
+			continue
+		}
 		if _, exists := result.writers[buf[0]]; exists {
 			continue
 		}
+
 		w, err := factory(buf[0])
 		if nil != err {
 			return nil, err

--- a/shamir.go
+++ b/shamir.go
@@ -201,15 +201,15 @@ func NewWriter(parts, threshold int, factory func(x byte) (io.Writer, error)) (i
 			// We cannot use a zero x coordinate otherwise the y values would be the intercepts i.e. the secret value itself.
 			continue
 		}
-		if _, exists := result.writers[buf[0]]; exists {
+		if _, exists := result.writers[x]; exists {
 			continue
 		}
 
-		w, err := factory(buf[0])
+		w, err := factory(x)
 		if nil != err {
 			return nil, err
 		}
-		result.writers[buf[0]] = w
+		result.writers[x] = w
 	}
 
 	return &result, nil

--- a/shamir_test.go
+++ b/shamir_test.go
@@ -26,6 +26,23 @@ func TestSplit_invalid(t *testing.T) {
 	}
 }
 
+func TestSplit_noZeroCoordinate(t *testing.T) {
+	secret := []byte("test")
+
+	for i := 0; i < 1000; i++ {
+		out, err := Split(secret, 5, 3)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		for x, _ := range out {
+			if x == 0 {
+				t.Fatal("found zero coordinate, the values therefore reveal the secret")
+			}
+		}
+	}
+}
+
 func TestSplit(t *testing.T) {
 	secret := []byte("test")
 
@@ -36,6 +53,25 @@ func TestSplit(t *testing.T) {
 
 	if len(out) != 5 {
 		t.Fatalf("bad: %v", out)
+	}
+
+	for _, share := range out {
+		if len(share) != len(secret) {
+			t.Fatalf("bad: %v", out)
+		}
+	}
+}
+
+func TestSplit_large(t *testing.T) {
+	secret := []byte("test")
+
+	out, err := Split(secret, 255, 255)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(out) != 255 {
+		t.Fatalf("wrong number of shards: %v", out)
 	}
 
 	for _, share := range out {


### PR DESCRIPTION
There is currently a serious bug whereby the zero x coordinate can be chosen. This reveals the full secret in that shard.